### PR TITLE
Fixes #16 - Ingot mould placement restrictions

### DIFF
--- a/common/src/main/java/com/ordana/molten_metals/blocks/MoldBlock.java
+++ b/common/src/main/java/com/ordana/molten_metals/blocks/MoldBlock.java
@@ -44,6 +44,6 @@ public class MoldBlock extends Block {
 
   public static boolean canAttach(LevelReader reader, BlockPos pos, Direction direction) {
     BlockPos blockPos = pos.relative(direction);
-    return reader.getBlockState(blockPos).isFaceSturdy(reader, blockPos, direction);
+    return reader.getBlockState(blockPos).isFaceSturdy(reader, blockPos, direction.getOpposite());
   }
 }


### PR DESCRIPTION
Corrects use of `Direction` in `canAttach` so that ingots can only be placed on blocks with a solid upper face (currently it checks the bottom face instead).